### PR TITLE
Allow regular github issue reference for commit messages

### DIFF
--- a/config/app-enterprise.yaml
+++ b/config/app-enterprise.yaml
@@ -12,7 +12,8 @@ ZAPPR_DEFAULT_CONFIG:
     message:
       patterns:
         - "^(?:(?:[a-zA-Z0-9_\\-]*|[a-zA-Z0-9_\\-]+\\/[a-zA-Z0-9_\\-]+)#|GH-)\\d+"
-        - "^#?[A-Z]+-[0-9]+"
+        - "^#?[A-Z]+-[0-9]+" # like JIRA-123
+        - "^#[0-9+]" # regular github pattern like #123
   approvals:
     minimum: 2
     ignore: none


### PR DESCRIPTION
For github enterprise, that is. Fixes #346