### PR TITLE
Fixes broken link

### DIFF
--- a/client/containers/Login.jsx
+++ b/client/containers/Login.jsx
@@ -65,7 +65,7 @@ class Login extends Component {
           </p>
         </div>
         <footer>
-          Made with ♥︎ by <a href='https://zalando.com'>Zalando</a>.<br/>
+          Made with ♥︎ by <a href='http://www.zalando.com/'>Zalando</a>.<br/>
           <a href='https://tech.zalando.com'>Zalando Tech</a> is <a href='https://tech.zalando.com/jobs'>hiring</a>!
         </footer>
       </section>


### PR DESCRIPTION
The URL https://zalando.com does not serve HTTPs.
Updated the URL to http://www.zalando.com/.