### PR TITLE
Track and expose custom metrics

### DIFF
--- a/config/system.yaml
+++ b/config/system.yaml
@@ -23,6 +23,7 @@ GITHUB_API_URL: https://api.github.com
 # that ZAPPR is going to run on.
 HOST_ADDR: http://127.0.0.1:8080
 APP_PORT: 3000
+METRICS_PORT: 3003
 NODE_ENV: development
 STATIC_DIR: ./dist/client
 

--- a/config/system.yaml
+++ b/config/system.yaml
@@ -24,6 +24,7 @@ GITHUB_API_URL: https://api.github.com
 HOST_ADDR: http://127.0.0.1:8080
 APP_PORT: 3000
 METRICS_PORT: 3003
+METRICS_ENABLED: true
 NODE_ENV: development
 STATIC_DIR: ./dist/client
 

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "passport": "0.3.2",
     "passport-github": "1.1.0",
     "passport-strategy": "1.0.0",
+    "prom-client": "3.4.6",
     "react": "15.0.1",
     "react-bootstrap": "0.29.0",
     "react-dom": "15.0.1",

--- a/server/metrics.js
+++ b/server/metrics.js
@@ -1,0 +1,16 @@
+import Koa from 'koa'
+import Router from 'koa-router'
+import { getCurrentMetrics } from './middleware/prometheus'
+
+export function metrics(router) {
+  return router.get('/metrics', ctx => {
+    ctx.body = getCurrentMetrics()
+  })
+}
+
+export default function initMetrics() {
+  const metricsRouter = metrics(Router())
+  const metricApp = new Koa()
+  return metricApp.use(metricsRouter.routes())
+                  .use(metricsRouter.allowedMethods())
+}

--- a/server/metrics.js
+++ b/server/metrics.js
@@ -10,7 +10,7 @@ export function metrics(router) {
 
 export default function initMetrics() {
   const metricsRouter = metrics(Router())
-  const metricApp = new Koa()
-  return metricApp.use(metricsRouter.routes())
-                  .use(metricsRouter.allowedMethods())
+  const metricsApp = new Koa()
+  return metricsApp.use(metricsRouter.routes())
+                   .use(metricsRouter.allowedMethods())
 }

--- a/server/middleware/prometheus.js
+++ b/server/middleware/prometheus.js
@@ -1,0 +1,65 @@
+import { Summary, Counter, register } from 'prom-client'
+
+export const RequestDuration = new Summary('api_response_time_ms', 'ms to handle a request', ['method', 'path'])
+export const RequestRate = new Counter('api_request_rate', 'number of requests to a route', ['method', 'path'])
+
+export function getCurrentMetrics() {
+  return register.metrics()
+}
+
+/**
+ * Middleware-generating function. Call this during app.use(). Will track request duration and number of requests
+ * for every route.
+ *
+ * @param router The instance of your koa-router.
+ * @param opts Options to provide for the middleware. Currently takes only `ignore`,
+ * an array of regexes that will be
+ * matched against every URL to decide if they should not be measured with prometheus
+ * @returns {function} Prometheus middleware
+ */
+export default function generatePrometheusMiddleware(router, opts = {}) {
+
+  const ROUTES = router.stack.map(({regexp, path}) => ({regexp, path}))
+
+  /**
+   * Maps a relative URL that was requested to a route.
+   *
+   * @param {string} url URL requested
+   * @returns {string} Route matched or the URL without query parameters
+   */
+  function mapToRoute(url) {
+    url = url.replace(/\?.*$/, '') // strip query params, who cares
+    const matchingRoutes = ROUTES.filter(route => new RegExp(route.regexp).test(url))
+    return matchingRoutes.length === 0 ? url : matchingRoutes[0].path
+  }
+
+  /**
+   * Takes a relative URL requested and decides if it should be measured.
+   *
+   * @param url URL requested
+   * @returns {boolean} False if metrics will be collected
+   */
+  function shouldIgnoreRequest(url) {
+    return Array.isArray(opts.ignore) ? opts.ignore.some(regex => regex.test(url)) : false
+  }
+
+  return async function prometheus(ctx, next) {
+    const {method, url} = ctx.request
+    const ignore = shouldIgnoreRequest(url)
+    if (ignore) {
+      // if it should not be tracked, just call next
+      await next()
+    } else {
+      // otherwise map to route
+      const path = mapToRoute(url)
+      // track request rate
+      RequestRate.inc({method, path}, 1)
+
+      // track time to respond
+      const start = Date.now()
+      await next()
+      const duration = Date.now() - start
+      RequestDuration.observe({method, path}, duration)
+    }
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -17,9 +17,9 @@ import DatabaseStore from './session/database-store'
 import { db } from './model'
 import { init as initPassport } from './passport/passport'
 import { logger } from '../common/debug'
-import {GITHUB_ERROR_TYPE} from './service/GithubServiceError'
-import {CHECK_ERROR_TYPE} from './handler/CheckHandlerError'
-import {REPO_ERROR_TYPE} from './handler/RepositoryHandlerError'
+import { GITHUB_ERROR_TYPE } from './service/GithubServiceError'
+import { CHECK_ERROR_TYPE } from './handler/CheckHandlerError'
+import { REPO_ERROR_TYPE } from './handler/RepositoryHandlerError'
 
 const log = logger('app', 'info')
 const app = new Koa()
@@ -56,25 +56,25 @@ const morganSkip = (req, res) => res.statusCode < nconf.get('MORGAN_THRESH')
 export function init(options = {}) {
   const passport = initPassport(options.PassportStrategy)
 
-  return app.
-  use(generatePrometheusMiddleware(router, {
-    ignore: [/^\/repository/]
-  })).
-  use(generateProblemMiddleware({
-    exposableErrorTypes: [
-      CHECK_ERROR_TYPE,
-      GITHUB_ERROR_TYPE,
-      REPO_ERROR_TYPE
-  ]})).
-  use(morgan(morganFormat, {skip: morganSkip})).
-  use(convert(session({store: store}))).
-  use(bodyParser()).
-  use(passport.initialize()).
-  use(passport.session()).
-  use(router.routes()).
-  use(router.allowedMethods()).
-  use(convert(serve(nconf.get('STATIC_DIR'), {index: 'none'}))).
-  use(renderStatic)
+  return app.use(generatePrometheusMiddleware(router, {
+              ignore: [/^\/repository/]
+            }))
+            .use(generateProblemMiddleware({
+              exposableErrorTypes: [
+                CHECK_ERROR_TYPE,
+                GITHUB_ERROR_TYPE,
+                REPO_ERROR_TYPE
+              ]
+            }))
+            .use(morgan(morganFormat, {skip: morganSkip}))
+            .use(convert(session({store: store})))
+            .use(bodyParser())
+            .use(passport.initialize())
+            .use(passport.session())
+            .use(router.routes())
+            .use(router.allowedMethods())
+            .use(convert(serve(nconf.get('STATIC_DIR'), {index: 'none'})))
+            .use(renderStatic)
 }
 
 /**
@@ -82,7 +82,10 @@ export function init(options = {}) {
  *
  * @param {number} port Port to listen on
  */
-async function start(port = nconf.get('APP_PORT'), metricsPort = nconf.get('METRICS_PORT')) {
+async function start(port = nconf.get('APP_PORT'), opts = {
+  metricsEnabled: nconf.get('METRICS_ENABLED'),
+  metricsPort: nconf.get('METRICS_PORT')
+}) {
   const umzug = new Umzug({
     storage: 'sequelize',
     logging: logger('migration', 'info'),
@@ -113,9 +116,11 @@ async function start(port = nconf.get('APP_PORT'), metricsPort = nconf.get('METR
   await db.sync()
   init().listen(port)
   log(`listening on port ${port}`)
-  const actualMetricsPort = metricsPort || 3003
-  initMetrics().listen(actualMetricsPort)
-  log(`metrics available on port ${actualMetricsPort}`)
+  if (opts.metricsEnabled) {
+    const actualMetricsPort = opts.metricsPort || 3003
+    initMetrics().listen(actualMetricsPort)
+    log(`metrics available on port ${actualMetricsPort}`)
+  }
 }
 
 if (require.main === module) {

--- a/server/service/GithubService.js
+++ b/server/service/GithubService.js
@@ -1,10 +1,12 @@
 import path from 'path'
 import nconf from '../nconf'
+import { Counter } from 'prom-client'
 import GithubServiceError from './GithubServiceError'
 import { joinURL, promiseFirst, decode, getIn } from '../../common/util'
 import { logger } from '../../common/debug'
 import { request } from '../util'
 
+const CallCounter = new Counter('github_api_requests', 'Status codes from Github API', ['type'])
 const debug = logger('github')
 const info = logger('github', 'info')
 const error = logger('github', 'error')
@@ -52,12 +54,21 @@ export class GithubService {
     const [response, body] = await request(options)
     const {statusCode} = response || {}
 
+    CallCounter.inc({type: 'total'}, 1)
     // 300 codes are for github membership checks
     if ([200, 201, 202, 203, 204, 300, 301, 302].indexOf(statusCode) < 0) {
       error(`${statusCode} ${method} ${path}`, response.body)
+      if (statusCode >= 400 && statusCode <= 499) {
+        CallCounter.inc({type: '4xx'}, 1)
+      } else if (statusCode >= 500 && statusCode <= 599) {
+        CallCounter.inc({ type: '5xx'}, 1)
+      }
       throw new GithubServiceError(response)
     }
-    else return body
+    else {
+      CallCounter.inc({type: 'success'}, 1)
+      return body
+    }
   }
 
   setCommitStatus(user, repo, sha, status, accessToken) {

--- a/test/server/metrics.test.js
+++ b/test/server/metrics.test.js
@@ -1,0 +1,26 @@
+import supertest from 'supertest-as-promised'
+import { expect } from 'chai'
+
+import initMetrics from '../../server/metrics'
+
+describe('Metrics', () => {
+  let request
+  let app
+
+  before(() => {
+    app = initMetrics()
+    request = supertest.agent(app.listen())
+  })
+
+  describe('GET /metrics', () => {
+    it('should output text', async(done) => {
+      try {
+        const result = await request.get('/metrics').expect(200)
+        expect(result.text.length).to.be.above(0)
+        done()
+      } catch (e) {
+        done(e)
+      }
+    })
+  })
+})


### PR DESCRIPTION
Fixes #376 

Exposes metrics in prometheus format:

~~~
# HELP api_response_time_ms ms to handle a request
# TYPE api_response_time_ms summary
api_response_time_ms{quantile="0.01",path="/api/repos",method="GET"} 162
api_response_time_ms{quantile="0.05",path="/api/repos",method="GET"} 162
api_response_time_ms{quantile="0.5",path="/api/repos",method="GET"} 1816
api_response_time_ms{quantile="0.9",path="/api/repos",method="GET"} 3470
api_response_time_ms{quantile="0.95",path="/api/repos",method="GET"} 3470
api_response_time_ms{quantile="0.99",path="/api/repos",method="GET"} 3470
api_response_time_ms{quantile="0.999",path="/api/repos",method="GET"} 3470
api_response_time_ms_sum{method="GET",path="/api/repos"} 3632
api_response_time_ms_count{method="GET",path="/api/repos"} 2
api_response_time_ms{quantile="0.01",path="/api/repos/:id/:type",method="PUT"} 454
api_response_time_ms{quantile="0.05",path="/api/repos/:id/:type",method="PUT"} 454
api_response_time_ms{quantile="0.5",path="/api/repos/:id/:type",method="PUT"} 855
api_response_time_ms{quantile="0.9",path="/api/repos/:id/:type",method="PUT"} 1256
api_response_time_ms{quantile="0.95",path="/api/repos/:id/:type",method="PUT"} 1256
api_response_time_ms{quantile="0.99",path="/api/repos/:id/:type",method="PUT"} 1256
api_response_time_ms{quantile="0.999",path="/api/repos/:id/:type",method="PUT"} 1256
api_response_time_ms_sum{method="PUT",path="/api/repos/:id/:type"} 1710
api_response_time_ms_count{method="PUT",path="/api/repos/:id/:type"} 2
api_response_time_ms{quantile="0.01",path="/api/repos/:id/:type",method="DELETE"} 939
api_response_time_ms{quantile="0.05",path="/api/repos/:id/:type",method="DELETE"} 939
api_response_time_ms{quantile="0.5",path="/api/repos/:id/:type",method="DELETE"} 939
api_response_time_ms{quantile="0.9",path="/api/repos/:id/:type",method="DELETE"} 939
api_response_time_ms{quantile="0.95",path="/api/repos/:id/:type",method="DELETE"} 939
api_response_time_ms{quantile="0.99",path="/api/repos/:id/:type",method="DELETE"} 939
api_response_time_ms{quantile="0.999",path="/api/repos/:id/:type",method="DELETE"} 939
api_response_time_ms_sum{method="DELETE",path="/api/repos/:id/:type"} 939
api_response_time_ms_count{method="DELETE",path="/api/repos/:id/:type"} 1
api_response_time_ms{quantile="0.01",path="/api/repos/:id/zapprfile",method="GET"} 472
api_response_time_ms{quantile="0.05",path="/api/repos/:id/zapprfile",method="GET"} 472
api_response_time_ms{quantile="0.5",path="/api/repos/:id/zapprfile",method="GET"} 530
api_response_time_ms{quantile="0.9",path="/api/repos/:id/zapprfile",method="GET"} 582
api_response_time_ms{quantile="0.95",path="/api/repos/:id/zapprfile",method="GET"} 582
api_response_time_ms{quantile="0.99",path="/api/repos/:id/zapprfile",method="GET"} 582
api_response_time_ms{quantile="0.999",path="/api/repos/:id/zapprfile",method="GET"} 582
api_response_time_ms_sum{method="GET",path="/api/repos/:id/zapprfile"} 1584
api_response_time_ms_count{method="GET",path="/api/repos/:id/zapprfile"} 3
# HELP api_request_rate number of requests to a route
# TYPE api_request_rate counter
api_request_rate{method="GET",path="/api/repos"} 2
api_request_rate{method="PUT",path="/api/repos/:id/:type"} 2
api_request_rate{method="DELETE",path="/api/repos/:id/:type"} 1
api_request_rate{method="GET",path="/api/repos/:id/zapprfile"} 3
# HELP github_api_requests Status codes from Github API
# TYPE github_api_requests counter
github_api_requests{type="total"} 11
github_api_requests{type="success"} 7
github_api_requests{type="4xx"} 4
~~~