### PR TITLE
Add possibility to ignore parts of user config

### DIFF
--- a/config/app-enterprise.yaml
+++ b/config/app-enterprise.yaml
@@ -11,6 +11,9 @@ VALID_PR_TEMPLATE_PATHS:
   - "/PULL_REQUEST_TEMPLATE"
   - "/PULL_REQUEST_TEMPLATE.txt"
   - "/PULL_REQUEST_TEMPLATE.md"
+IGNORE_USER_CONFIG:
+  - "approvals.pattern"
+  - "approvals.veto"
 ZAPPR_DEFAULT_CONFIG:
   autobranch:
     pattern: "{number}-{title}"

--- a/server/zapprfile/Configuration.js
+++ b/server/zapprfile/Configuration.js
@@ -1,6 +1,10 @@
 import yaml from 'js-yaml'
 import nconf from '../nconf'
 import mergeWith from 'lodash/mergeWith'
+import unset from 'lodash/unset'
+
+const DEFAULT_CONFIG = nconf.get('ZAPPR_DEFAULT_CONFIG') || {}
+const IGNORE_USER_CONFIG = nconf.get('IGNORE_USER_CONFIG') || []
 
 function mergeCustomizerFn(objValue, srcValue) {
   if (Array.isArray(objValue) && (Array.isArray(srcValue) || typeof srcValue === 'undefined')) {
@@ -9,18 +13,27 @@ function mergeCustomizerFn(objValue, srcValue) {
   }
 }
 
-const DEFAULT_CONFIG = nconf.get('ZAPPR_DEFAULT_CONFIG') || {}
+function getEffectiveConfiguration(userConfig, defaultConfig, ignorePaths) {
+  ignorePaths.forEach(path => unset(userConfig, path)) // unset mutates object ;_;
+  return mergeWith({}, defaultConfig, userConfig, mergeCustomizerFn)
+}
 
 export default class ZapprConfiguration {
-  constructor(fileContent, defaultConfig = DEFAULT_CONFIG) {
+  constructor(userConfig, defaultConfig = DEFAULT_CONFIG, ignorePaths = IGNORE_USER_CONFIG) {
     this.yamlParseError = null
     this.configuration = Object.assign({}, defaultConfig)
 
-    try {
-      const content = yaml.safeLoad(fileContent)
-      this.configuration = mergeWith({}, defaultConfig, content, mergeCustomizerFn)
-    } catch (e) {
-      this.yamlParseError = e.message
+    if (typeof userConfig === 'string') {
+      try {
+        const content = yaml.safeLoad(userConfig)
+        this.configuration = getEffectiveConfiguration(content, defaultConfig, ignorePaths)
+      } catch (e) {
+        this.yamlParseError = e.message
+      }
+    } else if (typeof userConfig === 'object' && !Array.isArray(userConfig)) {
+      this.configuration = getEffectiveConfiguration(userConfig, defaultConfig, ignorePaths)
+    } else {
+      throw new Error('ZapprConfiguration has to be called with a YAML String or a JSON object as first argument.')
     }
   }
 

--- a/test/server/zapprconfiguration.test.js
+++ b/test/server/zapprconfiguration.test.js
@@ -9,7 +9,50 @@ const DEFAULT_CONFIG = {
   }
 }
 
-describe('zapprfile', () => {
+describe('ZapprConfiguration', () => {
+
+  [true, false, 0, -1, 7, Infinity, NaN, undefined, null, []].forEach(throws => {
+    it(`should throw if called with ${throws}`, () => {
+        expect(() => new Configuration(throws)).to.throw
+    })
+  })
+
+  it('should ignore top-level paths', () => {
+    const config = new Configuration({
+        foo: 'bar',
+        baz: 'qux',
+        pattern: 'plus one'
+      }, {
+        baz: 'foo',
+        pattern: 'thumbs up'
+      },
+      ['baz', 'pattern'])
+    expect(config.getConfiguration()).to.deep.equal({
+      foo: 'bar',
+      baz: 'foo',
+      pattern: 'thumbs up'
+    })
+  })
+
+  it('should ignore nested paths', () => {
+    const config = new Configuration({
+        approvals: {
+          pattern: 'lgtm'
+        },
+        commit: {
+          message: {
+            patterns: ['ahhhhhh'],
+            willBeIgnoredToo: true,
+            furtherNesting: {
+              wontHelpEither: true
+            }
+          }
+        }
+      },
+      DEFAULT_CONFIG,
+      ['commit.message', 'approvals.pattern'])
+    expect(config.getConfiguration()).to.deep.equal(Object.assign({approvals: {}}, DEFAULT_CONFIG))
+  })
 
   it('should overwrite arrays correctly', () => {
     const content = 'commit:\n  message:\n    patterns:\n      - baz\n'


### PR DESCRIPTION
Fixes #315 

* Which parts to ignore is provided via `IGNORE_USER_CONFIG` configuration in the form of `ignore.this.path`
* This is passed to [_.unset](https://lodash.com/docs#unset)
* Afterwards remaining object is merged with default configuration
* Also `ZapprConfiguration` accepts an already parsed configuration for easier testing.