### PR TITLE
Ignore specification user config (enterprise)

### DIFF
--- a/config/app-enterprise.yaml
+++ b/config/app-enterprise.yaml
@@ -14,6 +14,7 @@ VALID_PR_TEMPLATE_PATHS:
 IGNORE_USER_CONFIG:
   - "approvals.pattern"
   - "approvals.veto"
+  - "specification"
 ZAPPR_DEFAULT_CONFIG:
   autobranch:
     pattern: "{number}-{title}"


### PR DESCRIPTION
Since we want to have the same specification config in the whole organization it doesn't make sense to have this configurable.