### PR TITLE
Cache node_modules between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
   - "5.7"
+cache:
+  directories:
+    - node_modules
 install:
   - npm install
   - npm install sqlite3


### PR DESCRIPTION
[Travis docs](https://docs.travis-ci.com/user/caching/).

This should shave around 3 minutes off our build time.