### PR TITLE
Fix not so optional dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/node:5.10-3
+FROM registry.opensource.zalan.do/stups/node:5.10-9
 
 ENV ZAPPR_HOME /opt/zappr
 
@@ -10,7 +10,7 @@ WORKDIR $ZAPPR_HOME
 COPY package.json $ZAPPR_HOME
 
 RUN npm install --production && \
-    npm install pg source-map node-tokens
+    npm install pg source-map
 
 COPY dist/ $ZAPPR_HOME/dist
 COPY config $ZAPPR_HOME/config

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "koa-static": "2.0.0",
     "lodash": "4.13.1",
     "nconf": "0.8.4",
+    "node-tokens": "0.0.9",
     "node-uuid": "1.4.7",
     "normalizr": "2.2.0",
     "passport": "0.3.2",
@@ -124,13 +125,12 @@
     "redux-thunk": "2.1.0",
     "request": "2.73.0",
     "sequelize": "3.23.6",
-    "umzug": "1.11.0"
+    "umzug": "1.11.0",
+    "winston": "2.2.0"
   },
   "optionalDependencies": {
     "pg": "4.5.6",
-    "sqlite3": "3.1.x",
-    "node-tokens": "0.0.9",
-    "winston": "2.2.0"
+    "sqlite3": "3.1.x"
   },
   "babel": {
     "env": {


### PR DESCRIPTION
Forgot that the optional audit transformers and shippers do still get loaded and thus `winston` and `node-tokens` are actually required.