### PR TITLE
Fix DB migrations

### DIFF
--- a/config/system.yaml
+++ b/config/system.yaml
@@ -36,7 +36,6 @@ DB_DRIVER: sqlite
 #DB_PASS: postgres
 #DB_HOST: 192.168.99.100
 #DB_PORT: 5432
-#DB_SCHEMA: zappr
 SQLITE_FILE: ./zappr.sqlite
 
 # Token encryption

--- a/docs/run-your-own.md
+++ b/docs/run-your-own.md
@@ -77,7 +77,6 @@ Zappr provides a whole lot of configuration options for flexibility.
 * `DB_USER`: Database user, might be `postgres` or you create a different user (recommended)
 * `DB_PASS`: Password for database user
 * `DB_NAME`: Which database to use
-* `DB_SCHEMA`: Which schema to use in the database
 
 ### Encryption
 

--- a/migrations/000-setup.js
+++ b/migrations/000-setup.js
@@ -221,7 +221,7 @@ module.exports.up = function up(queryInterface, Sequelize) {
           allowNull: false,
           defaultValue: Sequelize.NOW()
         }
-      })
+      }, {schema})
     })
   })
 }

--- a/migrations/000-setup.js
+++ b/migrations/000-setup.js
@@ -157,6 +157,10 @@ module.exports.up = function up(queryInterface, Sequelize) {
           type: Sequelize.TEXT,
           allowNull: false
         },
+        arguments: {
+          type: Sequelize.JSONB,
+          allowNull: false
+        },
         type: {
           type: Sequelize.ENUM([
             'approval',

--- a/migrations/000-setup.js
+++ b/migrations/000-setup.js
@@ -1,0 +1,231 @@
+const schema = 'zappr_data'
+
+module.exports.up = function up(queryInterface, Sequelize) {
+  // session
+  return Promise.all([
+    queryInterface.createTable('sessions', {
+      id: {
+        type: Sequelize.STRING,
+        primaryKey: true,
+        unique: true,
+        allowNull: false,
+        autoIncrement: false
+      },
+      json: {
+        type: Sequelize.JSONB,
+        allowNull: false
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW()
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW()
+      }
+    }, {
+      schema
+    }),
+    // user
+    queryInterface.createTable('users', {
+      id: {
+        type: Sequelize.BIGINT,
+        primaryKey: true,
+        unique: true,
+        allowNull: false,
+        autoIncrement: false
+      },
+      json: {
+        type: Sequelize.JSONB,
+        allowNull: false
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW()
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW()
+      }
+    }, {schema}),
+    // repository
+    queryInterface.createTable('repositories', {
+      id: {
+        type: Sequelize.BIGINT,
+        primaryKey: true,
+        unique: true,
+        allowNull: false,
+        autoIncrement: false
+      },
+      json: {
+        type: Sequelize.JSONB,
+        allowNull: false
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW()
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW()
+      }
+    }, {schema})
+  ]).then(function () {
+    return Promise.all([
+      // user repositories
+      queryInterface.createTable('user_repositories', {
+        userId: {
+          type: Sequelize.BIGINT,
+          references: {
+            model: {tableName: 'users', schema},
+            key: 'id'
+          }
+        },
+        repositoryId: {
+          type: Sequelize.BIGINT,
+          references: {
+            model: {tableName: 'repositories', schema},
+            key: 'id'
+          }
+        },
+        createdAt: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.NOW()
+        },
+        updatedAt: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.NOW()
+        }
+
+      }, {schema}),
+      // pull request
+      queryInterface.createTable('pull_requests', {
+        id: {
+          type: Sequelize.BIGINT,
+          primaryKey: true,
+          unique: true,
+          allowNull: false,
+          autoIncrement: true
+        },
+        number: {
+          type: Sequelize.INTEGER,
+          allowNull: false
+        },
+        last_push: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.NOW
+        },
+        repositoryId: {
+          type: Sequelize.BIGINT,
+          references: {
+            model: {tableName: 'repositories', schema},
+            key: 'id'
+          }
+        },
+        createdAt: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.NOW()
+        },
+        updatedAt: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.NOW()
+        }
+      }, {schema}),
+      // check
+      queryInterface.createTable('checks', {
+        id: {
+          type: Sequelize.BIGINT,
+          primaryKey: true,
+          unique: true,
+          allowNull: false,
+          autoIncrement: true
+        },
+        token: {
+          type: Sequelize.TEXT,
+          allowNull: false
+        },
+        type: {
+          type: Sequelize.ENUM([
+            'approval',
+            'autobranch',
+            'specification',
+            'commitmessage'
+          ]),
+          allowNull: false
+        },
+        repositoryId: {
+          type: Sequelize.BIGINT,
+          references: {
+            model: {tableName: 'repositories', schema},
+            key: 'id'
+          }
+        },
+        createdAt: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.NOW()
+        },
+        updatedAt: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.NOW()
+        }
+      }, {schema}),
+    ]).then(function () {
+      // frozen comment
+      return queryInterface.createTable('frozen_comments', {
+        id: {
+          type: Sequelize.BIGINT,
+          primaryKey: true,
+          unique: true,
+          allowNull: false,
+          autoIncrement: false
+        },
+        user: {
+          type: Sequelize.TEXT,
+          allowNull: false
+        },
+        created_at: {
+          type: Sequelize.DATE,
+          allowNull: false
+        },
+        body: {
+          type: Sequelize.TEXT,
+          allowNull: false
+        },
+        pullRequestId: {
+          type: Sequelize.BIGINT,
+          references: {
+            model: {tableName: 'pull_requests', schema},
+            key: 'id'
+          }
+        },
+        createdAt: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.NOW()
+        },
+        updatedAt: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.NOW()
+        }
+      })
+    })
+  })
+}
+
+module.exports.down = function down(queryInterface) {
+  return queryInterface.dropAllTables({schema})
+}

--- a/migrations/000-setup.js
+++ b/migrations/000-setup.js
@@ -85,14 +85,16 @@ module.exports.up = function up(queryInterface, Sequelize) {
           references: {
             model: {tableName: 'users', schema},
             key: 'id'
-          }
+          },
+          onDelete: 'cascade'
         },
         repositoryId: {
           type: Sequelize.BIGINT,
           references: {
             model: {tableName: 'repositories', schema},
             key: 'id'
-          }
+          },
+          onDelete: 'cascade'
         },
         createdAt: {
           type: Sequelize.DATE,

--- a/migrations/000-setup.js
+++ b/migrations/000-setup.js
@@ -106,7 +106,6 @@ module.exports.up = function up(queryInterface, Sequelize) {
           allowNull: false,
           defaultValue: Sequelize.NOW()
         }
-
       }, {schema}),
       // pull request
       queryInterface.createTable('pull_requests', {

--- a/migrations/001-remove-check-arguments.js
+++ b/migrations/001-remove-check-arguments.js
@@ -1,0 +1,21 @@
+const schema = 'zappr_data'
+
+module.exports.up = function up(queryInterface) {
+  return queryInterface.removeColumn({
+      tableName: 'checks',
+      schema
+    },
+    'arguments')
+}
+
+module.exports.down = function down(queryInterface) {
+  return queryInterface.addColumn({
+      tableName: 'checks',
+      schema
+    },
+    'arguments',
+    {
+      type: Sequelize.JSONB,
+      allowNull: false
+    })
+}

--- a/server/handler/CheckHandler.js
+++ b/server/handler/CheckHandler.js
@@ -39,8 +39,7 @@ class CheckHandler {
       return await Check.create({
         repositoryId: repoId,
         type,
-        token,
-        arguments: {}
+        token
       }, {
         attributes: {exclude: ['token']}
       })

--- a/server/model/Check.js
+++ b/server/model/Check.js
@@ -27,11 +27,6 @@ export default db.define('check', {
   type: {
     type: Sequelize.ENUM(...CHECK_TYPES),
     allowNull: false
-  },
-  arguments: {
-    type: Sequelize.JSONB,
-    allowNull: false,
-    get: deserializeJson('arguments')
   }
 }, {
   schema: db.schema,

--- a/server/model/Check.js
+++ b/server/model/Check.js
@@ -27,9 +27,22 @@ export default db.define('check', {
   type: {
     type: Sequelize.ENUM(...CHECK_TYPES),
     allowNull: false
+  },
+  createdAt: {
+    type: Sequelize.DATE,
+    allowNull: false,
+    defaultValue: Sequelize.NOW()
+  },
+  updatedAt: {
+    type: Sequelize.DATE,
+    allowNull: false,
+    defaultValue: Sequelize.NOW()
   }
 }, {
   schema: db.schema,
+  timestamps: true,
+  createdAt: 'createdAt',
+  updatedAt: 'updatedAt',
   instanceMethods: {
     /**
      * Never return the token in JSON.

--- a/server/model/Database.js
+++ b/server/model/Database.js
@@ -73,18 +73,11 @@ class Database extends Sequelize {
   }
 
   /**
-   * Create the database schema and sync all models.
-   *
-   * @returns {Promise}
+   * Creates tables. Use only in tests!
+   * @private
    */
-  async sync() {
-    const schemas = await db.showAllSchemas()
-
-    if (schemas.indexOf(this.schema) === -1) {
-      const result = await db.createSchema(this.schema)
-      log('created schema' + result)
-    }
-
+  async _sync() {
+    log(`syncing models...`)
     try {
       await User.sync()
       await Repository.sync()
@@ -96,6 +89,22 @@ class Database extends Sequelize {
       log('synced models')
     } catch (e) {
       error(e)
+    }
+  }
+
+  /**
+   * Create the database schemas
+   *
+   * @returns {Promise}
+   */
+  async createSchemas() {
+    const schemas = await db.showAllSchemas()
+
+    if (schemas.indexOf(this.schema) === -1) {
+      await db.createSchema('zappr_meta')
+      log('created schema zappr_meta')
+      const result = await db.createSchema(this.schema)
+      log('created schema' + result)
     }
   }
 }

--- a/server/model/Database.js
+++ b/server/model/Database.js
@@ -8,6 +8,8 @@ import { User, Repository, UserRepository, Check, PullRequest, Session, FrozenCo
 const log = logger('model')
 const error = logger('model', 'error')
 const encryptionService = EncryptionServiceCreator.create()
+const DATA_SCHEMA = 'zappr_data'
+const META_SCHEMA = 'zappr_meta'
 
 async function decryptToken(check) {
   const plain = await encryptionService.decrypt(check.token)
@@ -69,7 +71,7 @@ class Database extends Sequelize {
    * @returns {String}
    */
   get schema() {
-    return nconf.get('DB_SCHEMA')
+    return DATA_SCHEMA
   }
 
   /**
@@ -101,9 +103,9 @@ class Database extends Sequelize {
     const schemas = await db.showAllSchemas()
 
     if (schemas.indexOf(this.schema) === -1) {
-      await db.createSchema('zappr_meta')
+      await db.createSchema(META_SCHEMA)
       log('created schema zappr_meta')
-      const result = await db.createSchema(this.schema)
+      const result = await db.createSchema(DATA_SCHEMA)
       log('created schema' + result)
     }
   }

--- a/server/model/FrozenComment.js
+++ b/server/model/FrozenComment.js
@@ -20,9 +20,22 @@ export default db.define('frozen_comment', {
   body: {
     type: Sequelize.TEXT,
     allowNull: false
+  },
+  createdAt: {
+    type: Sequelize.DATE,
+    allowNull: false,
+    defaultValue: Sequelize.NOW()
+  },
+  updatedAt: {
+    type: Sequelize.DATE,
+    allowNull: false,
+    defaultValue: Sequelize.NOW()
   }
 }, {
   schema: db.schema,
+  timestamps: true,
+  createdAt: 'createdAt',
+  updatedAt: 'updatedAt',
   scopes: {
     pullRequest: prId => ({
       where: {

--- a/server/model/PullRequest.js
+++ b/server/model/PullRequest.js
@@ -21,7 +21,20 @@ export default db.define('pull_request', {
     type: Sequelize.DATE,
     allowNull: false,
     defaultValue: Sequelize.NOW
+  },
+  createdAt: {
+    type: Sequelize.DATE,
+    allowNull: false,
+    defaultValue: Sequelize.NOW()
+  },
+  updatedAt: {
+    type: Sequelize.DATE,
+    allowNull: false,
+    defaultValue: Sequelize.NOW()
   }
 }, {
-  schema: db.schema
+  schema: db.schema,
+  timestamps: true,
+  createdAt: 'createdAt',
+  updatedAt: 'updatedAt'
 })

--- a/server/model/Repository.js
+++ b/server/model/Repository.js
@@ -20,6 +20,16 @@ export default db.define('repository', {
     type: Sequelize.JSONB,
     allowNull: false,
     get: deserializeJson('json')
+  },
+  createdAt: {
+    type: Sequelize.DATE,
+    allowNull: false,
+    defaultValue: Sequelize.NOW()
+  },
+  updatedAt: {
+    type: Sequelize.DATE,
+    allowNull: false,
+    defaultValue: Sequelize.NOW()
   }
 }, {
   scopes: {
@@ -59,5 +69,8 @@ export default db.define('repository', {
       })
     }
   },
-  schema: db.schema
+  schema: db.schema,
+  timestamps: true,
+  createdAt: 'createdAt',
+  updatedAt: 'updatedAt'
 })

--- a/server/model/Session.js
+++ b/server/model/Session.js
@@ -5,7 +5,7 @@ import { deserializeJson, flattenToJson } from './properties'
 
 /**
  * PassportJS session.
- * 
+ *
  * FIXME: session should be encrypted
  */
 export default db.define('session', {
@@ -20,10 +20,23 @@ export default db.define('session', {
     type: Sequelize.JSONB,
     allowNull: false,
     get: deserializeJson('json')
+  },
+  createdAt: {
+    type: Sequelize.DATE,
+    allowNull: false,
+    defaultValue: Sequelize.NOW()
+  },
+  updatedAt: {
+    type: Sequelize.DATE,
+    allowNull: false,
+    defaultValue: Sequelize.NOW()
   }
 }, {
   instanceMethods: {
     flatten: flattenToJson
   },
-  schema: db.schema
+  schema: db.schema,
+  timestamps: true,
+  createdAt: 'createdAt',
+  updatedAt: 'updatedAt'
 })

--- a/server/model/User.js
+++ b/server/model/User.js
@@ -18,7 +18,20 @@ export default db.define('user', {
     type: Sequelize.JSONB,
     allowNull: false,
     get: deserializeJson('json')
+  },
+  createdAt: {
+    type: Sequelize.DATE,
+    allowNull: false,
+    defaultValue: Sequelize.NOW()
+  },
+  updatedAt: {
+    type: Sequelize.DATE,
+    allowNull: false,
+    defaultValue: Sequelize.NOW()
   }
 }, {
-  schema: db.schema
+  schema: db.schema,
+  timestamps: true,
+  createdAt: 'createdAt',
+  updatedAt: 'updatedAt'
 })

--- a/server/server.js
+++ b/server/server.js
@@ -110,10 +110,9 @@ async function start(port = nconf.get('APP_PORT'), opts = {
       columnType: new Sequelize.TEXT
     }
   })
+  await db.createSchemas()
   // apply migrations
   await umzug.up()
-  // sync models
-  await db.sync()
   init().listen(port)
   log(`listening on port ${port}`)
   if (opts.metricsEnabled) {

--- a/server/server.js
+++ b/server/server.js
@@ -112,7 +112,7 @@ async function start(port = nconf.get('APP_PORT'), opts = {
   })
   await db.createSchemas()
   // apply migrations
-  await umzug.up()
+  await umzug.up({ from: nconf.get('DB_UMZUG_FROM') || null})
   init().listen(port)
   log(`listening on port ${port}`)
   if (opts.metricsEnabled) {

--- a/test/server/model.test.js
+++ b/test/server/model.test.js
@@ -16,7 +16,7 @@ const users = {
 
 describe('Model', () => {
 
-  before(done => db.sync().then(done).catch(done))
+  before(done => db.createSchemas().then(db._sync).then(() => done()).catch(done))
 
   beforeEach(done => Promise.all([
     User.truncate(),
@@ -188,8 +188,10 @@ describe('Model', () => {
         await User.create({id: userId, json: user})
         await Repository.create({id: repoId, userId, json: repo})
         await Check.create({
-          id: checkId, token, repositoryId: repoId,
-          type: Approval.TYPE, arguments: {}
+          id: checkId,
+          token,
+          repositoryId: repoId,
+          type: Approval.TYPE
         })
         const savedCheck = await Check.findById(checkId)
         expect(savedCheck.get('token')).to.equal(token)


### PR DESCRIPTION
Fixes #419 

* `000-setup` contains the current database setup used with code on `master`
* ...except that the `user_repositories` association table has now foreign keys with `ON DELETE CASCADE` (wasn't the case before) — i hope this doesn't trip up Sequlize, but then again why would it
* Skip migrations with `DB_UMZUG_FROM` config setting
* `DB_SCHEMA` config setting is removed, our schemas are now always `zappr_data` and `zappr_meta`
* Removed column `checks.arguments` as we never used it with `001-remove-checks-arguments`

## TODO

- [x] Either have `createdAt`/`updatedAt` in models too or let them be autogenerated in migrations