### PR TITLE
Block pull request with labels

### DIFF
--- a/client/components/RepositoryBrowser.jsx
+++ b/client/components/RepositoryBrowser.jsx
@@ -36,7 +36,7 @@ export default class RepositoryBrowser extends Component {
         </Button>
       </Alert>
     } else if (!selected) {
-      content = <Alert bsStyle='info'>Please select a repository from the list to enable ZAPPR for it.</Alert>
+      content = <Alert bsStyle='info'>Please select a repository from the list to enable Zappr for it.</Alert>
     }
 
     return (

--- a/client/components/RepositoryCheck.jsx
+++ b/client/components/RepositoryCheck.jsx
@@ -20,7 +20,10 @@ const INFO_TEXT = {
   </p>,
   specification: <p>The specification check (<a
     href='https://zappr.readthedocs.io/en/latest/setup/#specification'>docs</a>) will verify that a pull request's title
-    and body conform to the length and content requirements.</p>
+    and body conform to the length and content requirements.</p>,
+  pullrequestlabels: <p>The pull request labels check will verify that an open pull request has (or does not have)
+    labels you defined before it can be merged. (Examples could be <code>Work in progress</code> or <code>Review needed</code>.)
+  </p>
 }
 
 export default class RepositoryCheck extends Component {

--- a/common/util.js
+++ b/common/util.js
@@ -128,6 +128,38 @@ export function setDifference(set1, set2) {
 }
 
 /**
+ * Returns a union of the sets provided
+ * @param sets
+ * @returns {Set}
+ */
+export function setUnion(...sets) {
+  return new Set(...sets)
+}
+
+/**
+ * Returns true if the two sets are equal
+ * @param set1
+ * @param set2
+ * @returns {boolean}
+ */
+export function setEquals(set1, set2) {
+  const symmetricDifference = setUnion(setDifference(set1, set2), setDifference(set2, set1))
+  return symmetricDifference.size === 0
+}
+
+/**
+ * Returns a new set that is the intersection of two sets provided (only items that are in both)
+ *
+ * @param set1
+ * @param set2
+ * @returns {Set} intersect(set1, set2)
+ */
+export function setIntersection(set1, set2) {
+  const symmetricDifference = setUnion(setDifference(set1, set2), setDifference(set2, set1))
+  return setDifference(setUnion(set1, set2), symmetricDifference)
+}
+
+/**
  * Map over the keys and values of an object.
  *
  * @param {Object} object

--- a/config/app-enterprise.yaml
+++ b/config/app-enterprise.yaml
@@ -45,3 +45,6 @@ ZAPPR_DEFAULT_CONFIG:
       contains-issue-number: true
     template:
       differs-from-body: true
+  pull-request:
+    labels:
+      additional: true

--- a/config/app-opensource.yaml
+++ b/config/app-opensource.yaml
@@ -45,3 +45,6 @@ ZAPPR_DEFAULT_CONFIG:
       contains-issue-number: true
     template:
       differs-from-body: true
+  pull-request:
+    labels:
+      additional: true

--- a/config/system.yaml
+++ b/config/system.yaml
@@ -100,6 +100,10 @@ ZAPPR_WELCOME_TEXT: |
     * Configure how many approvals your pull request needs before merging
     * Extensively configure who can approve or veto in your project
 
+  ## Pull Request guidelines
+
+    * Block a PR until it has the required set of labels (e.g. `reviewed`).
+
   ## Specification guidelines
 
     * Configure minimum length of pull request title and description

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -156,3 +156,20 @@ specification:
      # is different from pull request body
      differs-from-body: true
 ~~~
+
+### Pull Request Labels
+
+With the Pull Request Labels check you can block a pull request until it has the required set of labels. For instance you could use a label `WIP` to mark work in progress (and block merges) together with a label `reviewed` indicate that review is finished (and the pull request can be merged).
+
+It is configured under `pull-request.labels` and supports two options:
+
+~~~ yaml
+pull-request:
+  labels:
+    # pull request cannot be merged without these labels
+    required:
+      - reviewed
+    # pull request cannot be merged with these labels
+    verboten:
+      - WIP
+~~~

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -169,7 +169,6 @@ pull-request:
     # pull request cannot be merged without these labels
     required:
       - reviewed
-    # pull request cannot be merged with these labels
-    verboten:
-      - WIP
+    # allow additional labels to be present. true is the default..
+    additional: true
 ~~~

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "npm run test-common && npm run test-client && npm run test-server",
     "test-common": "DEBUG='zappr:test' NODE_ENV=test BABEL_ENV=test BABEL_DISABLE_CACHE=1 mocha --recursive --compilers js:babel-register test/common/",
+    "test-common:watch": "DEBUG='zappr:test' NODE_ENV=test BABEL_ENV=test BABEL_DISABLE_CACHE=1 mocha --recursive --compilers js:babel-register test/common/ --reporter min --watch",
     "test-client": "DEBUG='zappr:test' BABEL_ENV=test BABEL_DISABLE_CACHE=1 mocha --recursive --compilers js:babel-register test/client/",
     "test-server": "DEBUG='zappr:test' MORGAN_THRESH=999 NODE_ENV=test BABEL_ENV=test BABEL_DISABLE_CACHE=1 SQLITE_FILE=':memory:' mocha --recursive --compilers js:babel-register test/server/",
     "test-server:watch": "DEBUG='zappr:test' MORGAN_THRESH=999 NODE_ENV=test BABEL_ENV=test BABEL_DISABLE_CACHE=1 SQLITE_FILE=':memory:' mocha --recursive --compilers js:babel-register test/server/ --reporter min --watch",

--- a/server/checks/Check.js
+++ b/server/checks/Check.js
@@ -1,3 +1,14 @@
+export function getPayloadFn(context) {
+  return function createStatePayload(description, state = 'success') {
+    return {
+      state,
+      context,
+      description
+    }
+  }
+}
+
+
 export default class Check {
   /**
    * @param {string} event

--- a/server/checks/CommitMessage.js
+++ b/server/checks/CommitMessage.js
@@ -1,4 +1,4 @@
-import Check from './Check'
+import Check, {getPayloadFn} from './Check'
 import { logger } from '../../common/debug'
 import { getIn } from '../../common/util'
 import * as EVENTS from '../model/GithubEvents'
@@ -8,6 +8,7 @@ const info = logger(CHECK_TYPE, 'info')
 const error = logger(CHECK_TYPE, 'error')
 const context = 'zappr/commit/message'
 const SHORT_SHA_LENGTH = 7
+const createStatePayload = getPayloadFn(context)
 
 /**
  * Takes RegExps and returns a function that takes a string
@@ -32,14 +33,6 @@ export function getAnyMatcherFn(regexes) {
  */
 function isMergeCommit({parents}) {
   return Array.isArray(parents) && parents.length > 1
-}
-
-function createStatePayload(description, state = 'success') {
-  return {
-    state,
-    context,
-    description
-  }
 }
 
 export default class CommitMessage extends Check {

--- a/server/checks/PullRequestLabels.js
+++ b/server/checks/PullRequestLabels.js
@@ -46,7 +46,7 @@ export default class PullRequestLabels extends Check {
     const repoName = repository.name
     const fullName = repository.full_name
     try {
-      const {required, additional} = getIn(config, ['pull-request', 'labels'], {required: [], additional: false})
+      const {required, additional} = getIn(config, ['pull-request', 'labels'], {required: [], additional: true})
       if (required.length === 0) {
         // there is nothing to check against
         info(`${fullName}#${number}: Configuration is empty, nothing to do.`)

--- a/server/checks/PullRequestLabels.js
+++ b/server/checks/PullRequestLabels.js
@@ -1,0 +1,65 @@
+import Check, { getPayloadFn } from './Check'
+import { PULL_REQUEST } from '../model/GithubEvents'
+import { getIn, setIntersection, setDifference } from '../../common/util';
+import { logger } from '../../common/debug'
+
+const CHECK_TYPE = 'pullrequestlabels'
+const info = logger(CHECK_TYPE, 'info')
+const error = logger(CHECK_TYPE, 'error')
+const debug = logger(CHECK_TYPE)
+const context = 'zappr/pr/labels'
+const createStatePayload = getPayloadFn(context)
+
+export function generateStatus(labels, checkConfig) {
+  const {required, verboten} = checkConfig
+  const requiredSet = new Set(required)
+  const verbotenSet = new Set(verboten)
+  const labelSet = new Set(labels)
+
+  const verbotenLabels = setIntersection(labelSet, verbotenSet)
+  if (verbotenLabels.size > 0) {
+    return createStatePayload(`PR has verboten labels: ${[...verbotenLabels].join(', ')}.`, 'failure')
+  }
+  const missingLabels = setDifference(requiredSet, labelSet)
+  if (missingLabels.size > 0) {
+    return createStatePayload(`PR misses required labels: ${[...missingLabels].join(', ')}.`, 'failure')
+  }
+  return createStatePayload(`PR has all required labels.`)
+}
+
+export default class PullRequestLabels extends Check {
+  static TYPE = CHECK_TYPE;
+  static HOOK_EVENTS = [PULL_REQUEST];
+  static NAME = 'Pull request labels check';
+
+  constructor(github) {
+    super()
+    this.github = github
+  }
+
+  async execute(config, hookPayload, token) {
+    const {action, repository, number, pull_request} = hookPayload
+    const repoOwner = repository.owner.login
+    const repoName = repository.name
+    const fullName = repository.full_name
+    try {
+      const {required, verboten} = getIn(config, ['pull-request', 'labels'], {required: [], verboten: []})
+      if (required.length === 0 && verboten.length === 0) {
+        // there is nothing to check against
+        info(`${fullName}#${number}: Configuration is empty, nothing to do.`)
+        return
+      }
+      if (['labeled', 'unlabeled', 'opened', 'reopened'].indexOf(action) !== -1 && pull_request.state === 'open') {
+        const labels = await this.github.getIssueLabels(repoOwner, repoName, number, token)
+        const status = generateStatus(labels, {required, verboten})
+        debug(`${fullName}#${number}: ${labels} (required: ${required}, verboten: ${verboten})`)
+        info(`${fullName}#${number}: Set status to ${status.state}.`)
+        await this.github.setCommitStatus(repoOwner, repoName, pull_request.head.sha, status, token)
+      }
+    } catch(e) {
+      error(`${fullName}#${number}: Could not execute Pull Request Labels check`, e)
+      const status = createStatePayload(`Error: ${e.message}`, 'error')
+      await this.github.setCommitStatus(repoOwner, repoName, pull_request.head.sha, status, token)
+    }
+  }
+}

--- a/server/checks/index.js
+++ b/server/checks/index.js
@@ -2,19 +2,22 @@ import Approval from './Approval'
 import Autobranch from './Autobranch'
 import CommitMessage from './CommitMessage'
 import Specification from './Specification'
+import PullRequestLabels from './PullRequestLabels'
 
 const CHECKS = {
   [Approval.TYPE]: Approval,
   [Autobranch.TYPE]: Autobranch,
   [CommitMessage.TYPE]: CommitMessage,
-  [Specification.TYPE]: Specification
+  [Specification.TYPE]: Specification,
+  [PullRequestLabels.TYPE]: PullRequestLabels
 }
 
 export const CHECK_NAMES = {
   [Approval.TYPE]: Approval.NAME,
   [Autobranch.TYPE]: Autobranch.NAME,
   [CommitMessage.TYPE]: CommitMessage.NAME,
-  [Specification.TYPE]: Specification.NAME
+  [Specification.TYPE]: Specification.NAME,
+  [PullRequestLabels.TYPE]: PullRequestLabels.NAME
 }
 
 export const CHECK_TYPES = Object.keys(CHECKS)
@@ -23,4 +26,4 @@ export function getCheckByType(type) {
   return CHECKS[type]
 }
 
-export { Approval, Autobranch, CommitMessage, Specification }
+export { Approval, Autobranch, CommitMessage, Specification, PullRequestLabels }

--- a/server/handler/HookHandler.js
+++ b/server/handler/HookHandler.js
@@ -1,4 +1,10 @@
-import { Approval, Autobranch, CommitMessage, Specification } from '../checks'
+import {
+  Approval,
+  Autobranch,
+  CommitMessage,
+  Specification,
+  PullRequestLabels
+} from '../checks'
 import createAuditService from '../service/AuditServiceCreator'
 import { logger } from '../../common/debug'
 import { githubService as defaultGithubService } from '../service/GithubService'
@@ -27,6 +33,7 @@ class HookHandler {
     this.autobranch = new Autobranch(this.githubService)
     this.commitMessage = new CommitMessage(this.githubService)
     this.specification = new Specification(this.githubService)
+    this.pullrequestlabels = new PullRequestLabels(this.githubService)
   }
 
   /**
@@ -71,6 +78,11 @@ class HookHandler {
       if (CommitMessage.isTriggeredBy(event)) {
         getToken(repo, CommitMessage.TYPE).then(token =>
           this.commitMessage.execute(config, payload, token)
+        )
+      }
+      if (PullRequestLabels.isTriggeredBy(event)) {
+        getToken(repo, PullRequestLabels.TYPE).then(token =>
+          this.pullrequestlabels.execute(config, payload, token)
         )
       }
     }

--- a/server/service/GithubService.js
+++ b/server/service/GithubService.js
@@ -30,6 +30,7 @@ const API_URL_TEMPLATES = {
   REF: '/repos/${owner}/${repo}/git/refs/heads/${branch}',
   CREATE_REF: '/repos/${owner}/${repo}/git/refs',
   PR_COMMITS: '/repos/${owner}/${repo}/pulls/${number}/commits',
+  ISSUE: '/repos/${owner}/${repo}/issues/${number}',
   PULL_REQUESTS: '/repos/${owner}/${repo}/pulls',
   BRANCH: '/repos/${owner}/${repo}/branches/${branch}',
   COMMITS: '/repos/${owner}/${repo}/git/commits',
@@ -438,6 +439,24 @@ export class GithubService {
     const title = ZAPPR_WELCOME_TITLE
     const body = ZAPPR_WELCOME_TEXT
     return this.createPullRequest(user, repo, ZAPPR_WELCOME_BRANCH_NAME, base, title, body, accessToken)
+  }
+
+  /**
+   * Returns all labels present on an issue/pull request.
+   *
+   * @param user
+   * @param repo
+   * @param number
+   * @param token
+   * @returns {Array<string>}
+   */
+  async getIssueLabels(user, repo, number, token) {
+    const url = API_URL_TEMPLATES.ISSUE
+                                 .replace('${owner}', user)
+                                 .replace('${repo}', repo)
+                                 .replace('${number}', number)
+    const issue = await this.fetchPath('GET', url, null, token)
+    return issue.labels.map(l => l.name)
   }
 }
 

--- a/test/common/util.test.js
+++ b/test/common/util.test.js
@@ -5,6 +5,9 @@ import {
   encode,
   decode,
   setDifference,
+  setEquals,
+  setUnion,
+  setIntersection,
   promiseReduce,
   promiseFirst,
   symbolToString
@@ -20,6 +23,55 @@ describe('common/util', () => {
       expect(symbolToString(1)).to.equal(1)
       const noSymbol = {}
       expect(symbolToString(noSymbol)).to.equal(noSymbol)
+    })
+  })
+
+  describe('setUnion', () => {
+    it('returns a union of sets', () => {
+      const set1 = new Set([1, 2, 3])
+      const set2 = new Set([1, 2])
+      const union = setUnion(set1, set2)
+      expect(union.size).to.equal(3)
+      expect([...union]).to.deep.equal([1, 2, 3])
+    })
+
+    it('works on arrays', () => {
+      const array1 = [1, 2, 3]
+      const array2 = [1, 2]
+      const union = setUnion(array1, array2)
+      expect(union.size).to.equal(3)
+      expect([...union]).to.deep.equal([1, 2, 3])
+    })
+  })
+
+  describe('setEquals', () => {
+    it('should return true if sets are equal', () => {
+      const set1 = new Set([1, 2, 3])
+      const set2 = new Set([3, 2, 1])
+      expect(setEquals(set1, set2)).to.be.true
+    })
+
+    it('should return false if sets are not equal', () => {
+      const set1 = new Set([1, 2, 3])
+      const set2 = new Set([1, 2])
+      expect(setEquals(set1, set2)).to.be.false
+    })
+  })
+
+  describe('setIntersection', () => {
+    it('should return the intersection of two sets', () => {
+      const set1 = new Set([1, 2, 3, 4])
+      const set2 = new Set([2, 3])
+      const intersect = setIntersection(set1, set2)
+      expect(intersect.size).to.equal(2)
+      expect([...intersect]).to.deep.equal([2, 3])
+    })
+
+    it('should return empty set if sets are disjoint', () => {
+      const set1 = new Set([1, 2, 3, 4])
+      const set2 = new Set([5, 6, 7, 8])
+      const intersect = setIntersection(set1, set2)
+      expect(intersect.size).to.equal(0)
     })
   })
 

--- a/test/server/pullrequestlabels.test.js
+++ b/test/server/pullrequestlabels.test.js
@@ -1,0 +1,142 @@
+import sinon from 'sinon'
+import { expect } from 'chai'
+import {GithubService} from '../../server/service/GithubService'
+import PullRequestLabels, { generateStatus } from '../../server/checks/PullRequestLabels'
+
+
+describe('Pull Request Labels', () => {
+  describe('#generateStatus', () => {
+    it('generates failure when verboten labels are present', () => {
+      const labels = ['work-in-progress', 'approved']
+      const verboten = ['work-in-progress']
+      const status = generateStatus(labels, {verboten, required: []})
+      expect(status.description).to.equal(`PR has verboten labels: work-in-progress.`)
+      expect(status.state).to.equal('failure')
+    })
+
+    it('generates failure when required labels are missing', () => {
+      const labels = ['approved']
+      const required = ['ux-approved', 'approved']
+      const status = generateStatus(labels, {required, verboten: []})
+      expect(status.description).to.equal(`PR misses required labels: ux-approved.`)
+      expect(status.state).to.equal('failure')
+    })
+
+    it('checks verboten first', () => {
+      const labels = ['approved', 'ux-approved', 'work-in-progress']
+      const required = ['ux-approved', 'approved']
+      const verboten = ['work-in-progress']
+      const status = generateStatus(labels, {required, verboten})
+      expect(status.description).to.equal(`PR has verboten labels: work-in-progress.`)
+      expect(status.state).to.equal('failure')
+    })
+
+    it('generates success otherwise', () => {
+      const labels = ['approved']
+      const required = ['approved']
+      const status = generateStatus(labels, {required, verboten: []})
+      expect(status.description).to.equal('PR has all required labels.')
+      expect(status.state).to.equal('success')
+    })
+  })
+
+  describe('#execute', () => {
+    let prLabels, github
+    beforeEach(() => {
+      github = sinon.createStubInstance(GithubService)
+      prLabels = new PullRequestLabels(github)
+    })
+
+    const TOKEN = 'token'
+    const PAYLOAD = {
+      number: 1,
+      action: 'labeled',
+      pull_request: {
+        state: 'open',
+        head: {
+          sha: 'commit-id'
+        }
+      },
+      repository: {
+        name: 'hello-world',
+        owner: {
+          login: 'prayerslayer'
+        }
+      }
+    }
+    const CONFIG = {
+      'pull-request': {
+        labels: {
+          required: ['approved'],
+          verboten: ['wip']
+        }
+      }
+    }
+    const REACT_ON = ['labeled', 'unlabeled', 'opened', 'reopened']
+    const IGNORE = ['synchronize', 'assigned', 'unassigned', 'closed', 'edited']
+    const ALL = [...REACT_ON, ...IGNORE]
+    ALL.forEach(action =>
+      it(`ignores everything with state = closed`, async(done) => {
+        try {
+          await prLabels.execute(CONFIG, Object.assign({}, PAYLOAD, {action, pull_request: {state: 'closed'}}), TOKEN)
+          expect(github.getIssueLabels.called).to.be.false
+          done()
+        } catch (e) {
+          done(e)
+        }
+      }))
+
+    REACT_ON.forEach(action =>
+      it(`reacts on "${action}"`, async(done) => {
+        try {
+          await prLabels.execute(CONFIG, Object.assign({}, PAYLOAD, {action}), TOKEN)
+          expect(github.getIssueLabels.called).to.be.true
+          done()
+        } catch (e) {
+          done(e)
+        }
+      }))
+
+    IGNORE.forEach(action =>
+      it(`does not react on "${action}"`, async(done) => {
+        try {
+          await prLabels.execute(CONFIG, Object.assign({}, PAYLOAD, {action}), TOKEN)
+          expect(github.getIssueLabels.called).to.be.false
+          done()
+        } catch (e) {
+          done(e)
+        }
+      }))
+
+    it('does nothing when config is empty', async(done) => {
+      try {
+        await prLabels.execute({}, PAYLOAD, TOKEN)
+        expect(github.getIssueLabels.called).to.be.false
+        done()
+      } catch (e) {
+        done(e)
+      }
+    })
+
+    it('calls githubService with correct arguments', async(done) => {
+      try {
+        github.getIssueLabels = sinon.stub().returns(['wip'])
+        await prLabels.execute(CONFIG, PAYLOAD, TOKEN)
+        expect(github.getIssueLabels.args).to.deep.equal([
+          ['prayerslayer', 'hello-world', 1, TOKEN]
+        ])
+        const expectedStatus = {
+          state: 'failure',
+          context: 'zappr/pr/labels',
+          description: `PR has verboten labels: wip.`
+        }
+        expect(github.setCommitStatus.args).to.deep.equal([
+          ['prayerslayer', 'hello-world', 'commit-id', expectedStatus, TOKEN]
+        ])
+        done()
+      } catch (e) {
+        done(e)
+      }
+    })
+  })
+})


### PR DESCRIPTION
Fixes #323 

Introduces a new check with context `zappr/pr/labels` that

* fetches labels of PR on `labeled`, `unlabeled`, `opened` and `reopened`
* compares them to configuration
* sets commit status accordingly.

Configuration looks like this (**BIKESHEDDING OPPORTUNITY**):

~~~ yaml
pull-request:
  labels:
    # these have to be present on PR
    required:
      - approved
    additional: false # do not allow additional labels
~~~

### Checklist

- [x] Updated welcome text and RTD docs
- [x] Unit tests
- [x] Updated default configuration (`additional: false`)
- [x] Tested manually
