### PR TITLE
added support for task lists (#440)

### DIFF
--- a/server/checks/PullRequestTasks.js
+++ b/server/checks/PullRequestTasks.js
@@ -1,0 +1,82 @@
+import Check, { getPayloadFn } from './Check'
+import { PULL_REQUEST } from '../model/GithubEvents'
+import { logger } from '../../common/debug'
+
+const CHECK_TYPE = 'pullrequesttasks'
+const CONTEXT = 'zappr/pr/tasks'
+const info = logger(CHECK_TYPE, 'info')
+const error = logger(CHECK_TYPE, 'error')
+const debug = logger(CHECK_TYPE)
+const createStatePayload = getPayloadFn(CONTEXT)
+
+function hasOpenTasks(pr) {
+  const regex = /(-|\*) \[(\s|x)\]/g;
+  let count = 0;
+  let repoName = pr.head.repo.full_name;
+  let prNo = pr.number;
+  let match;
+
+  while ((match = regex.exec(pr.body)) !== null) {
+    // This is necessary to avoid infinite loops with zero-width matches
+    if (match.index === regex.lastIndex) {
+      regex.lastIndex++;
+    }
+
+    let task = match[0];
+    let marker = match[2];
+
+    debug(`${repoName}#${prNo}: Processing task: ${task}`);
+
+    if (marker === " ") {
+      count++;
+    }
+  }
+
+  info(`${repoName}#${prNo}: PR has ${count} open tasks.`);
+
+  return count > 0;
+}
+
+export default class PullRequestTasks extends Check {
+  static TYPE = CHECK_TYPE;
+  static CONTEXT = CONTEXT;
+  static HOOK_EVENTS = [PULL_REQUEST];
+  static NAME = 'Pull request tasks check'
+
+  constructor(github) {
+    super()
+    this.github = github;
+  }
+
+  async execute(config, hookPayload, token) {
+    const {action, repository, number, pull_request} = hookPayload
+    const repoOwner = repository.owner.login
+    const repoName = repository.name
+    const fullName = repository.full_name
+    let status;
+
+    try {
+      // TODO: configuration settings
+
+      if (pull_request.state === 'open' && ['opened', 'edited', 'reopened'].indexOf(action) !== -1) {
+        let msg;
+
+        if (hasOpenTasks(pull_request)) {
+          msg = `${fullName}#${number}: Failed the PR due to open tasks.`;
+          info(msg);
+          status = createStatePayload(msg, 'failure');
+        } else {
+          msg = `${fullName}#${number}: PR has no open tasks.`;
+          info(msg);
+          status = createStatePayload(msg);
+        }
+
+        await this.github.setCommitStatus(repoOwner, repoName, pull_request.head.sha, status, token);
+      }
+    } catch (e) {
+      error(`${fullName}#${number}: Could not execute Pull Request Tasks check`, e)
+      status = createStatePayload(`Error: ${e.message}`, 'error')
+      await this.github.setCommitStatus(repoOwner, repoName, pull_request.head.sha, status, token);
+    }
+  }
+}

--- a/server/checks/index.js
+++ b/server/checks/index.js
@@ -3,13 +3,15 @@ import Autobranch from './Autobranch'
 import CommitMessage from './CommitMessage'
 import Specification from './Specification'
 import PullRequestLabels from './PullRequestLabels'
+import PullRequestTasks from './PullRequestTasks'
 
 const CHECKS = {
   [Approval.TYPE]: Approval,
   [Autobranch.TYPE]: Autobranch,
   [CommitMessage.TYPE]: CommitMessage,
   [Specification.TYPE]: Specification,
-  [PullRequestLabels.TYPE]: PullRequestLabels
+  [PullRequestLabels.TYPE]: PullRequestLabels,
+  [PullRequestTasks.TYPE]: PullRequestTasks
 }
 
 export const CHECK_NAMES = {
@@ -17,7 +19,8 @@ export const CHECK_NAMES = {
   [Autobranch.TYPE]: Autobranch.NAME,
   [CommitMessage.TYPE]: CommitMessage.NAME,
   [Specification.TYPE]: Specification.NAME,
-  [PullRequestLabels.TYPE]: PullRequestLabels.NAME
+  [PullRequestLabels.TYPE]: PullRequestLabels.NAME,
+  [PullRequestTasks.TYPE]: PullRequestTasks.NAME
 }
 
 export const CHECK_TYPES = Object.keys(CHECKS)
@@ -26,4 +29,4 @@ export function getCheckByType(type) {
   return CHECKS[type]
 }
 
-export { Approval, Autobranch, CommitMessage, Specification, PullRequestLabels }
+export { Approval, Autobranch, CommitMessage, Specification, PullRequestLabels, PullRequestTasks }

--- a/server/handler/HookHandler.js
+++ b/server/handler/HookHandler.js
@@ -3,7 +3,8 @@ import {
   Autobranch,
   CommitMessage,
   Specification,
-  PullRequestLabels
+  PullRequestLabels,
+  PullRequestTasks
 } from '../checks'
 import createAuditService from '../service/AuditServiceCreator'
 import { logger } from '../../common/debug'
@@ -34,6 +35,7 @@ class HookHandler {
     this.commitMessage = new CommitMessage(this.githubService)
     this.specification = new Specification(this.githubService)
     this.pullrequestlabels = new PullRequestLabels(this.githubService)
+    this.pullrequesttasks = new PullRequestTasks(this.githubService)
   }
 
   /**
@@ -83,6 +85,11 @@ class HookHandler {
       if (PullRequestLabels.isTriggeredBy(event)) {
         getToken(repo, PullRequestLabels.TYPE).then(token =>
           this.pullrequestlabels.execute(config, payload, token)
+        )
+      }
+      if (PullRequestTasks.isTriggeredBy(event)) {
+        getToken(repo, PullRequestTasks.TYPE).then(token =>
+          this.pullrequesttasks.execute(config, payload, token)
         )
       }
     }

--- a/server/model/GithubEvents.js
+++ b/server/model/GithubEvents.js
@@ -60,8 +60,8 @@ export const PUBLIC = 'public'
  */
 export const PULL_REQUEST_REVIEW_COMMENT = 'pull_request_review_comment'
 /**
- * Any time a Pull Request is assigned, unassigned, labeled, unlabeled, opened, closed, reopened, or synchronized
- * (updated due to a new push in the branch that the pull request is tracking).
+ * Any time a Pull Request is assigned, unassigned, labeled, unlabeled, opened, edited, closed, reopened,
+ * or synchronized (updated due to a new push in the branch that the pull request is tracking).
  */
 export const PULL_REQUEST = 'pull_request'
 /**


### PR DESCRIPTION
Hi Everyone,

I've added support for task lists in pull requests. I haven't written the tests yet, but I'll. But before that, can somebody help me with the following problem?

During development, when I make a request for failing the commit, I'm getting 404 from GitHub API. But when I try the same request manually on the console, I'm getting 200 OK. Below is my request details. Can someone please help me with that?

```
$ cat <<EOF|http POST https://api.github.com/repos/tunix/zappr/statuses/b057484e4d5241751a4efd979b2f7b9aec916f3b "User-Agent:Zappr (+http://xxx.com:9999)" "Authorization:token xxx"
{"state":"failure","context":"zappr/pr/tasks","description":"tunix/zappr#4: Failed the PR due to open tasks."}
EOF
HTTP/1.1 201 Created
```

I'm getting below log when I try it through zappr:

```
zappr:github:error 2016-10-10T21:52:57Z 404 POST /repos/tunix/zappr/statuses/b057484e4d5241751a4efd979b2f7b9aec916f3b +464ms { message: 'Not Found', documentation_url: 'https://developer.github.com/v3' }
```

I'm also getting following error when I run tests against the server:

```
  235 passing (6s)
  1 failing

  1) API "before each" hook for "should work with token and no session":
     TypeError: Cannot read property 'map' of undefined
      at test/MountebankClient.js:75:44
      at next (native)
      at step (test/MountebankClient.js:29:191)
      at test/MountebankClient.js:29:361
      at process._tickDomainCallback (internal/process/next_tick.js:129:7)
```