### PR TITLE
#226 fix relative image path

### DIFF
--- a/docs/images.css
+++ b/docs/images.css
@@ -7,7 +7,7 @@
 }
 
 .wy-menu[role="navigation"]:after {
-    content: url(../img/banner_tiny.png);
+    content: url("img/banner_tiny.png");
     position: relative;
     left: 10px;
 }


### PR DESCRIPTION
#226 The path to the image has to be relative to the CSS file's path.
(was wrong in my first commit, that's why RTD doesn't show the logo now)