### PR TITLE
perform package upgrades during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM registry.opensource.zalan.do/stups/node:6.9-cd35
 
+RUN apt-get update && apt-get dist-upgrade -y
+
 ENV ZAPPR_HOME /opt/zappr
 ENV ZAPPR_CONFIG $ZAPPR_HOME/config/config.yaml
 


### PR DESCRIPTION
Quick fix to get rid of CVES: Update ubuntu packages during the docker build.