### PR TITLE
Ignore approvals from robot users

### DIFF
--- a/server/checks/Approval.js
+++ b/server/checks/Approval.js
@@ -1,5 +1,4 @@
 import Check from './Check'
-import nconf from '../nconf'
 import AuditEvent from '../service/audit/AuditEvent'
 import { logger, formatDate } from '../../common/debug'
 import { promiseReduce, getIn, toGenericComment } from '../../common/util'
@@ -7,7 +6,7 @@ import * as EVENTS from '../model/GithubEvents'
 import * as AUDIT_EVENTS from '../service/audit/AuditEventTypes'
 import * as _ from 'lodash'
 
-const IGNORE_LOGIN_RE = nconf.get('IGNORE_LOGIN_RE') || [/-robot^/]
+const IGNORE_LOGIN_RE =[/-robot^/]
 
 const context = 'zappr'
 const info = logger('approval', 'info')

--- a/server/checks/Approval.js
+++ b/server/checks/Approval.js
@@ -6,7 +6,7 @@ import * as EVENTS from '../model/GithubEvents'
 import * as AUDIT_EVENTS from '../service/audit/AuditEventTypes'
 import * as _ from 'lodash'
 
-const IGNORE_LOGIN_RE =[/-robot^/]
+const IGNORE_LOGIN_RE =[/-robot$/]
 
 const context = 'zappr'
 const info = logger('approval', 'info')
@@ -20,7 +20,7 @@ const error = logger('approval', 'error')
    * @returns {Boolean} `true` if the approval should be counted
    */
 function commenterIsNotIgnored (login) {
-  return IGNORE_LOGIN_RE.reduce((accumulator, currentValue) => accumulator && !RegExp(currentValue).test(login), true)
+  return IGNORE_LOGIN_RE.reduce((accumulator, currentValue) => accumulator && !RegExp(currentValue).test(login), true);
 }
 
 

--- a/server/checks/Approval.js
+++ b/server/checks/Approval.js
@@ -468,7 +468,7 @@ export default class Approval extends Check {
           return
         }
         const author = hookPayload.comment.user.login
-        if (author.endsWith('-robot') {
+        if (author.endsWith('-robot')) {
           debug(`${repository.full_name}#${issue.number}: Ignoring comment, it was created by a robot user.`)
           return
         }

--- a/server/checks/Approval.js
+++ b/server/checks/Approval.js
@@ -212,7 +212,7 @@ export default class Approval extends Check {
     // filter ignored users
     const potentialApprovalComments = comments.filter(comment => {
                                                 const login = comment.user
-                                                const include = ignore.indexOf(login) === -1
+                                                const include = (ignore.indexOf(login) === -1 && !login.endsWith('-robot'));
                                                 if (!include) {
                                                   info('%s: Ignoring user: %s.', fullName, login)
                                                 }

--- a/server/checks/Approval.js
+++ b/server/checks/Approval.js
@@ -467,6 +467,11 @@ export default class Approval extends Check {
           debug(`${repository.full_name}#${issue.number}: Ignoring comment, not a PR`)
           return
         }
+        const author = hookPayload.comment.user.login
+        if (author.endsWith('-robot') {
+          debug(`${repository.full_name}#${issue.number}: Ignoring comment, it was created by a robot user.`)
+          return
+        }
         sha = pr.head.sha
         // set status to pending first
         await this.github.setCommitStatus(user, repoName, sha, pendingPayload, token)
@@ -479,7 +484,6 @@ export default class Approval extends Check {
         if (['edited', 'deleted'].indexOf(action) !== -1 && !commentAlreadyFrozen) {
           // check if it was edited by someone else than the original author
           const editor = hookPayload.sender.login
-          const author = hookPayload.comment.user.login
           if (editor !== author) {
             // OMFG
             const comment = toGenericComment(hookPayload.comment)

--- a/test/server/approval.test.js
+++ b/test/server/approval.test.js
@@ -20,7 +20,11 @@ const ISSUE_PAYLOAD = {
   issue: {
     number: 2
   },
-  comment: {}
+  comment: {
+    user: {
+      login: 'mickeymouse'
+    }
+  }
 }
 const CLOSED_PR = {
   number: 3,


### PR DESCRIPTION
Currently robot users can create approval comments as part of the build process and they will be counted.