### PR TITLE
#522 fix: Fix for edited and deleted by another user outdated comment

### DIFF
--- a/server/checks/Approval.js
+++ b/server/checks/Approval.js
@@ -508,7 +508,9 @@ export default class Approval extends Check {
               created_at: comment.created_at
             }
             await this.pullRequestHandler.onAddFrozenComment(dbPR.id, frozenComment)
-            frozenComments.push(frozenComment)
+            if (new Date(comment.created_at) > dbPR.last_push) {
+              frozenComments.push(frozenComment)
+            }
             info(`${repository.full_name}#${issue.number}: ${editor} ${action} ${author}'s comment ${commentId}, it's now frozen.`)
           }
         }

--- a/test/server/approval.test.js
+++ b/test/server/approval.test.js
@@ -761,6 +761,152 @@ describe('Approval#execute', () => {
         done(e)
       }
     })
+
+    it(`should not take into account ${action} by another user outdated comment`, async(done) => {
+      try {
+        const pullRequestNumber = 123
+
+        const pullRequest = {
+          number: pullRequestNumber,
+          updated_at: '2016-03-02T13:37:00Z',
+          state: 'open',
+          user: {
+            login: 'stranger'
+          },
+          head: {
+            sha: 'abcd1234'
+          }
+        }
+
+        const openPullRequestWebhook = {
+          action: 'opened',
+          number: pullRequestNumber,
+          repository: DEFAULT_REPO,
+          pull_request: {
+            number: pullRequestNumber,
+            updated_at: '2016-03-02T13:37:00Z',
+            state: 'open',
+            user: {
+              login: 'stranger'
+            },
+            head: {
+              sha: 'abcd1234'
+            }
+          }
+        }
+
+        const synchronizePullRequestWebhook = Object.assign({}, openPullRequestWebhook, {
+          action: 'synchronize'
+        })
+
+        const commentWebhook = {
+          action: 'created',
+          repository: DEFAULT_REPO,
+          issue: {
+            number: pullRequestNumber
+          },
+          comment: {
+            id: 1,
+            user: {
+              login: 'bar'
+            }
+          }
+        }
+
+        const commentModificationWebhook = {
+          action: action,
+          repository: DEFAULT_REPO,
+          issue: {
+            number: pullRequestNumber
+          },
+          changes: {
+            body: {
+              from: ':+1:'
+            }
+          },
+          comment: {
+            id: 1,
+            body: ':+1: :+1:',
+            created_at: '2016-08-15T13:03:28Z',
+            user: {
+              login: 'bar'
+            }
+          },
+          sender: {
+            login: 'foo'
+          }
+        }
+
+        github.getPullRequest = sinon.stub()
+          .withArgs(DEFAULT_REPO.owner.login, DEFAULT_REPO.name, pullRequestNumber, TOKEN)
+          .returns(pullRequest)
+        pullRequestHandler.getOrCreateDbPullRequest = sinon.stub()
+          .withArgs(DB_REPO_ID, pullRequestNumber)
+          .returns(DB_PR)
+
+        await approval.execute(DEFAULT_CONFIG, EVENTS.PULL_REQUEST, openPullRequestWebhook, TOKEN, DB_REPO_ID)
+        expect(github.setCommitStatus.callCount).to.equal(2)
+        expect(github.setCommitStatus.args[1][3].state).to.equal('pending')
+        expect(github.setCommitStatus.args[1][3].description).to.equal('This PR needs 2 more approvals (0/2 given).')
+
+        github.setCommitStatus = sinon.spy()
+
+        github.getComments = sinon.stub()
+          .returns([{
+            id: 1,
+            body: ':+1:',
+            user: 'bar'
+          }])
+
+        await approval.execute(DEFAULT_CONFIG, EVENTS.ISSUE_COMMENT, commentWebhook, TOKEN, DB_REPO_ID)
+
+        expect(github.setCommitStatus.callCount).to.equal(2)
+        expect(github.setCommitStatus.args[1][3].state).to.equal('pending')
+        expect(github.setCommitStatus.args[1][3].description).to.equal('This PR needs 1 more approvals (1/2 given).')
+
+        github.setCommitStatus = sinon.spy()
+
+        await approval.execute(DEFAULT_CONFIG, EVENTS.PULL_REQUEST, synchronizePullRequestWebhook, TOKEN, DB_REPO_ID)
+
+        expect(github.setCommitStatus.callCount).to.equal(1)
+        expect(github.setCommitStatus.args[0][3].state).to.equal('pending')
+        expect(github.setCommitStatus.args[0][3].description).to.equal('This PR needs 2 more approvals (0/2 given).')
+
+        github.setCommitStatus = sinon.spy()
+
+        github.getComments = sinon.stub()
+          .returns([{
+            id: 2,
+            body: ':+1:',
+            user: 'foo'
+          }])
+
+        await approval.execute(DEFAULT_CONFIG, EVENTS.ISSUE_COMMENT, commentWebhook, TOKEN, DB_REPO_ID)
+
+        expect(github.setCommitStatus.callCount).to.equal(2)
+        expect(github.setCommitStatus.args[1][3].state).to.equal('pending')
+        expect(github.setCommitStatus.args[1][3].description).to.equal('This PR needs 1 more approvals (1/2 given).')
+
+        github.setCommitStatus = sinon.spy()
+
+        github.getComments = sinon.stub()
+          .returns([{
+            id: 2,
+            body: ':+1:',
+            user: 'foo'
+          }])
+
+        await approval.execute(DEFAULT_CONFIG, EVENTS.ISSUE_COMMENT, commentModificationWebhook, TOKEN, DB_REPO_ID)
+
+        expect(github.setCommitStatus.callCount).to.equal(2)
+        expect(github.setCommitStatus.args[1][3].state).to.equal('pending')
+        expect(github.setCommitStatus.args[1][3].description).to.equal('This PR needs 1 more approvals (1/2 given).')
+
+        done()
+      } catch (e) {
+        done(e)
+      }
+    })
   })
 
   it('should not freeze newly created comments', async(done) => {


### PR DESCRIPTION
Fix for https://github.com/zalando/zappr/issues/522

New frozen comment was added to the `frozenComments` without `created_at` check. 