### PR TITLE
adds readthedocs theme to mkdocs.yaml to fix overlapping header

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Zappr
 site_favicon: img/favicon.ico
+theme: readthedocs
 repo_url: https://github.com/zalando/zappr
 docs_dir: docs
 pages:


### PR DESCRIPTION
fixes https://github.com/zalando/zappr/issues/548
This PR adds the readthedocs theme to the mkdocs.yaml to fix the overlapping header and improve overall  Documentation UI.