### PR TITLE
webpack-dev-server version bump to 3.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "temp": "0.8.3",
     "url-loader": "0.5.7",
     "webpack": "1.13.1",
-    "webpack-dev-server": "1.14.1",
+    "webpack-dev-server": "3.1.11",
     "winston": "2.2.0"
   },
   "dependencies": {


### PR DESCRIPTION
as per https://github.com/zalando/zappr/network/alert/package.json/webpack-dev-server/open