### PR TITLE
feat: Support webhook url config key

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -66,6 +66,11 @@ VALID_PR_TEMPLATE_PATHS:
   - "/PULL_REQUEST_TEMPLATE"
   - "/PULL_REQUEST_TEMPLATE.txt"
   - "/PULL_REQUEST_TEMPLATE.md"
+
+# Explicit webhook url to use for receiving webhooks from Github
+# If this is commented out, Zappr uses "<HOST_ADDR config value>/api/hook' as the webhook url
+# HOOK_URL: http://mywebhookdomain/zappr/api/hook
+
 ZAPPR_DEFAULT_CONFIG:
   autobranch:
     pattern: "{number}-{title}"

--- a/docs/run-your-own.md
+++ b/docs/run-your-own.md
@@ -30,6 +30,7 @@ Zappr provides a whole lot of configuration options for flexibility.
 * `GITHUB_HOOK_SECRET`: Secret value used to verify only Github calls Zappr
 * `GITHUB_UI_URL`: URL to Github web user interface
 * `GITHUB_API_URL`: URL to Github API
+* `HOOK_URL`: Optional explicit webhook url to use for receiving webhooks from Github. Required if there is a proxy or load balancer that receives traffic from the internet and forwards it to Zappr.
 
 ### Server
 

--- a/server/service/GithubService.js
+++ b/server/service/GithubService.js
@@ -268,7 +268,8 @@ export class GithubService {
   async updateWebhookFor(user, repo, events, accessToken) {
     debug(`${user}/${repo}: updating webhook with events: ${events.join(", ")}`)
     let path = API_URL_TEMPLATES.HOOK.replace('${owner}', user).replace('${repo}', repo)
-    let hook_url = nconf.get('HOST_ADDR') + '/api/hook'
+    const HOOK_URL = nconf.get('HOOK_URL')
+    let hook_url = HOOK_URL ? HOOK_URL : nconf.get('HOST_ADDR') + '/api/hook'
     // payload for hook
     let payload = {
       name: 'web',

--- a/test/server/github.test.js
+++ b/test/server/github.test.js
@@ -317,4 +317,75 @@ describe('The Github service', () => {
       }
     })
   })
+
+  describe('#updateWebhookFor', () => {
+    it('should build webhook url from host address', async(done) => {
+      try {
+        const USER = 'user'
+        const REPO = 'repo'
+        const TOKEN = 'token'
+
+        github.fetchPath.returns([])
+        nconf.set('HOOK_URL', null)
+
+        await github.updateWebhookFor(USER, REPO, [], TOKEN)    
+        expect(github.fetchPath.args).to.deep.equal([
+          ['GET', `/repos/${USER}/${REPO}/hooks`,
+            null,
+            TOKEN],
+          ['POST', `/repos/${USER}/${REPO}/hooks`,
+            {
+              name: 'web',
+              active: true,
+              events: [],
+              config: {
+                url: nconf.get('HOST_ADDR') + '/api/hook',
+                content_type: 'json',
+                secret: nconf.get('GITHUB_HOOK_SECRET')
+              }
+            },
+            TOKEN]
+        ])
+
+        done()
+      } catch (e) {
+        done(e)
+      }
+    })
+
+    it('should use provided webhook url', async(done) => {
+      try {
+        const USER = 'user'
+        const REPO = 'repo'
+        const TOKEN = 'token'
+        const HOOK_URL = 'hookurl'
+
+        github.fetchPath.returns([])
+        nconf.set('HOOK_URL', HOOK_URL)
+
+        await github.updateWebhookFor(USER, REPO, [], TOKEN)
+        expect(github.fetchPath.args).to.deep.equal([
+          ['GET', `/repos/${USER}/${REPO}/hooks`,
+            null,
+            TOKEN],
+          ['POST', `/repos/${USER}/${REPO}/hooks`,
+            {
+              name: 'web',
+              active: true,
+              events: [],
+              config: {
+                url: HOOK_URL,
+                content_type: 'json',
+                secret: nconf.get('GITHUB_HOOK_SECRET')
+              }
+            },
+            TOKEN]
+        ])
+
+        done()
+      } catch (e) {
+        done(e)
+      }
+    })
+  })
 })


### PR DESCRIPTION
Implements #561 
Adds a new config key `HOOK_URL` to support explicitly setting the webhook url to be used by Zappr