### PR TITLE
fix: add milestone & merge checks to enum_checks_type

### DIFF
--- a/migrations/007-add-prmilestone-enum-value.js
+++ b/migrations/007-add-prmilestone-enum-value.js
@@ -1,0 +1,8 @@
+module.exports.up = function up(queryInterface) {
+  return queryInterface.sequelize.query(`ALTER TYPE zappr_data.enum_checks_type ADD VALUE IF NOT EXISTS 'pullrequestmilestone';`)
+}
+
+module.exports.down = function down() {
+  // there is no good downgrade
+  return Promise.resolve()
+}

--- a/migrations/008-add-prmergecommit-enum-value.js
+++ b/migrations/008-add-prmergecommit-enum-value.js
@@ -1,0 +1,8 @@
+module.exports.up = function up(queryInterface) {
+  return queryInterface.sequelize.query(`ALTER TYPE zappr_data.enum_checks_type ADD VALUE IF NOT EXISTS 'pullrequestmergecommit';`)
+}
+
+module.exports.down = function down() {
+  // there is no good downgrade
+  return Promise.resolve()
+}


### PR DESCRIPTION
I tried to enable `Pull request milestone check` for one of my repos at https://zappr.opensource.zalan.do.

It always fails with
```
Error during check processing
Check pullrequestmilestone already exists for repository [...].
```

Tried local with a commit before those checks to generate the old schema, same error after updating. Then I added the migration files and it worked.

If possible 6de017b should be also ported to the production version.