### PR TITLE
docs: fix indentation in specification example

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -156,9 +156,9 @@ specification:
     contains-url: true
     # contains an issue number
     contains-issue-number: true
-   template:
-     # is different from pull request body
-     differs-from-body: true
+  template:
+    # is different from pull request body
+    differs-from-body: true
 ~~~
 
 ### Pull Request Labels


### PR DESCRIPTION
Copypasted the example to our zappr file and zappr wasn't able to parse it since
the indentation is off.