### PR TITLE
Delete OSSMetadata file, not needed anymore

### DIFF
--- a/OSSMETADATA
+++ b/OSSMETADATA
@@ -1,1 +1,0 @@
-osslifecycle=active


### PR DESCRIPTION
As we are not relying on OSSMetadata anymore it should be removed from the sourcecode.