### PR TITLE
Deprecate LGTM in the competitor docs

### DIFF
--- a/docs/competitors.md
+++ b/docs/competitors.md
@@ -22,7 +22,7 @@ To help you decide if Zappr's the right tool for your use case, we've compared i
 
 ## LGTM
 
-**Deprecated** : [lgtm.co](https://lgtm.co) is no longer available, and the [source code](https://github.com/lgtmco/lgtm) for the project has been marked as archived. As the semmle, the company owning LGTM, has joined forces with GitHub, we might expect to see similar features integrated with GitHub natively at some point.
+**Deprecated** : [lgtm.co](https://lgtm.co) is no longer available, and the [source code](https://github.com/lgtmco/lgtm) for the project has been marked as *archived*. As [semmle](https://semmle.com/), the company owning LGTM, has joined forces with GitHub, we might expect to see similar features integrated into GitHub natively at some point.
 
 [LGTM](https://lgtm.co/docs/overview/) works in a fashion very similar to Zappr. Some differences to note:
  

--- a/docs/competitors.md
+++ b/docs/competitors.md
@@ -1,15 +1,8 @@
 # Comparison to Other, Similar Solutions
 
-*Last update: 15th August, 2016*
+*Last update: 14th February, 2020*
 
 To help you decide if Zappr's the right tool for your use case, we've compared it to other, similar solutions:
-
-## LGTM
-
-[LGTM](https://lgtm.co/docs/overview/) works in a fashion very similar to Zappr. Some differences to note:
- 
- * LGTM requires you to keep a MAINTAINERS file to identify valid approvers. This is good practice anyways, but with Zappr you can reference entire GitHub organizations, project collaborators, or even single users.
- * LGTM gives you approvals for PRs. Zappr gives you that, as well as veto power for different approver groups, commit message checks, automatic branch creation, and heuristics for specifications, with more to come.
 
 ## PullApprove
 
@@ -26,3 +19,12 @@ To help you decide if Zappr's the right tool for your use case, we've compared i
 * ReviewNinja offers a web UI that supports GitHub interactions. Zappr is built to encourage you to do your work only on GitHub, or as much as possible. If we could drop the Zappr web UI, we would.
 * ReviewNinja gives you more detailed reviews — i.e., you can mark specific code sections to be fixed. On Zappr, you can only give approvals or vetoes.
 * On Zappr, you must review every file in a pull request; there is no equivalent to `.ninjaignore`.
+
+## LGTM
+
+**Deprecated** : [lgtm.co](https://lgtm.co) is no longer available, and the [source code](https://github.com/lgtmco/lgtm) for the project has been marked as archived. As the semmle, the company owning LGTM, has joined forces with GitHub, we might expect to see similar features integrated with GitHub natively at some point.
+
+[LGTM](https://lgtm.co/docs/overview/) works in a fashion very similar to Zappr. Some differences to note:
+ 
+ * LGTM requires you to keep a MAINTAINERS file to identify valid approvers. This is good practice anyways, but with Zappr you can reference entire GitHub organizations, project collaborators, or even single users.
+ * LGTM gives you approvals for PRs. Zappr gives you that, as well as veto power for different approver groups, commit message checks, automatic branch creation, and heuristics for specifications, with more to come.


### PR DESCRIPTION
I marked competitor lgtm.co as deprecated, as https://lgtm.co is no longer available.

I moved the LGTM description to the very bottom. Further added some speculation about how LGTM might come to github.com through the Semmle acquisition.

Not sure if that is a good idea :)

So alternatively one could also remove the LGTM block completely?