### PR TITLE
Add configuration parameter DB_SSL

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -39,6 +39,7 @@ DB_USER: postgres
 DB_PASS: postgres
 # DB_HOST: 192.168.99.100
 DB_PORT: 5432
+DB_SSL: false
 
 # Token encryption
 # Options: [~, fake, kms]

--- a/server/model/Database.js
+++ b/server/model/Database.js
@@ -117,6 +117,9 @@ export const db = new Database(
   nconf.get('DB_PASS'),
   {
     dialect: "postgres",
+    dialectOptions: {
+      ssl: nconf.get('DB_SSL') === 'true' || nconf.get('DB_SSL') === true
+    },
     host: nconf.get('DB_HOST'),
     port: nconf.get('DB_PORT'),
     logging: log,


### PR DESCRIPTION
The parameter is used to connect to postgres while using SSL.
By default SSL is off and the behavior will not change uless
SSL is set to true.