### PR TITLE
Update .zappr.yaml: set X-Zalando-Team to machinery

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -5,4 +5,4 @@ approvals:
       from:
         orgs:
           - zalando
-X-Zalando-Team: opensource
+X-Zalando-Team: machinery


### PR DESCRIPTION
This will reflect the actual application owner and allow to see Zappr builds under our team in CDP.