### PR TITLE
[AUTOMATED] Update to nodejs 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/library/node-12-alpine:latest
+FROM registry.opensource.zalan.do/library/node-20-alpine:latest
 
 ENV ZAPPR_HOME /opt/zappr
 ENV ZAPPR_CONFIG $ZAPPR_HOME/config/config.yaml

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -3,7 +3,7 @@ version: "2017-09-20"
 dependencies:
   - id: node
     type: docker
-    ref: registry.opensource.zalan.do/library/node-12-alpine
+    ref: registry.opensource.zalan.do/library/node-20-alpine
 
 pipeline:
   - id: build_and_publish
@@ -13,7 +13,7 @@ pipeline:
       - desc: Build
         cmd: |
           function npm {
-            docker run -i --rm -v "$(pwd):/workspace" -w /workspace registry.opensource.zalan.do/library/node-12-alpine:latest npm "$@"
+            docker run -i --rm -v "$(pwd):/workspace" -w /workspace registry.opensource.zalan.do/library/node-20-alpine:latest npm "$@"
           }
           npm install --no-optional
           npm run dist


### PR DESCRIPTION
The Container Platform team is in the process of updating the Kubernetes node OS from Ubuntu 20.04 to Ubuntu 22.04.
With the switch to Ubuntu 22.04, it has been discovered that nodejs 18 and below are not compatible with Ubuntu 22.04 because of changes from cgroup v1 to cgroup v2 for managing the containers on the nodes.
The issue can be observed as high memory usage and OOMKill for applications running with nodejs 18 or below.

This automated Pull Request updates the base image to nodejs 20 which is compatible with Ubuntu 22.04 Kubernetes nodes.

Please help validate that your application is compatible with nodejs 20.