### PR TITLE
add retirement note; remove cdp pipeline automation and image upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+## [DEPRECATED]
+
+### The project has been deprecated.
+
+### https://zappr.opensource.zalando.de is out of service.
+
+---
+
 ![zappr](client/img/banner_tiny.png)
 
 **Approval checks for GitHub pull requests.**

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -1,10 +1,5 @@
 version: "2017-09-20"
 
-dependencies:
-  - id: node
-    type: docker
-    ref: registry.opensource.zalan.do/library/node-12-alpine
-
 pipeline:
   - id: build_and_publish
     type: script
@@ -27,4 +22,4 @@ pipeline:
             IMAGE_NAME="registry-write.opensource.zalan.do/machinery/zappr-pr-test:${COMMIT_ID}-${CDP_TARGET_REPOSITORY_COUNTER}"
           fi
           docker build -t "${IMAGE_NAME}" .
-          docker push "${IMAGE_NAME}"
+          # docker push "${IMAGE_NAME}"


### PR DESCRIPTION
Contributes to: https://github.bus.zalan.do/machinery/planning/issues/2702

- adds a retirement note
- removes CDP pipeline automation

https://zappr.readthedocs.io documentation is not updated because I think we should remove it.